### PR TITLE
Render user's profile on the server side

### DIFF
--- a/apis/nakvaksin.instance.ts
+++ b/apis/nakvaksin.instance.ts
@@ -20,6 +20,9 @@ instance.interceptors.response.use((response) => {
         setUserToken(response.headers['x-auth-token']);
     }
 
+    // TODO: if status code returns unauthorized (expired token),
+    // clear userToken and kick user out to homepage
+
     return response;
 });
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,12 +1,11 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { useUser } from '../hooks/useUser';
 
 export default function Header() {
     const { user, logout } = useUser();
-    const [isMounted, setIsMounted] = useState(false);
     const router = useRouter();
 
     useEffect(() => {
@@ -20,10 +19,6 @@ export default function Header() {
             router.push('/');
         }
     }, [user, router.pathname]);
-
-    useEffect(() => {
-        setIsMounted(true);
-    }, []);
 
     return (
         <header className="z-20 w-full xl:px-0 px-2">
@@ -39,18 +34,7 @@ export default function Header() {
                     </Link>
                 </div>
                 <div className="flx sm:w-1/2 flex justify-end ">
-                    {/*
-                    We are checking for both user and isMounted.
-                    This is needed otherwise React will prompt 'Warning: Expected server HTML to contain a matching <div> in <div>.'
-        
-                    This is because the cached user profile cannot be retrieved on the server side, as the server does not contain the client's cookie
-                    Hence, the rendered DOM is different, causing the error.
-                    To prevent this, we need to make sure the component can only be rendered on the client.
-                    UseEffect is not run on the server
-                    
-                    More info: https://github.com/vercel/next.js/discussions/17443
-                    */}
-                    {user && isMounted && (
+                    {user && (
                         <div className="inline">
                             <h3 className="inline pr-4">Welcome {user.displayName} </h3>
                             <button

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,22 +1,29 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useUser } from '../hooks/useUser';
 
 export default function Header() {
     const { user, logout } = useUser();
+    const [isMounted, setIsMounted] = useState(false);
     const router = useRouter();
 
     useEffect(() => {
         // TODO: Move this outside of header, probably in _app.tsx (need to create an AuthProvider I think)
         const publicRoutes = ['/', '/login', '/resetpassword'];
+        const isPublicRoute = publicRoutes.includes(router.pathname);
+        const isAuthenticated = !!user;
 
-        // Redirect user to landing page if unauthenticated
-        if (user == null && !publicRoutes.includes(router.pathname)) {
+        // Redirect unauthenticated user to home
+        if (!isAuthenticated && !isPublicRoute) {
             router.push('/');
         }
     }, [user, router.pathname]);
+
+    useEffect(() => {
+        setIsMounted(true);
+    }, []);
 
     return (
         <header className="z-20 w-full xl:px-0 px-2">
@@ -32,7 +39,18 @@ export default function Header() {
                     </Link>
                 </div>
                 <div className="flx sm:w-1/2 flex justify-end ">
-                    {user && (
+                    {/*
+                    We are checking for both user and isMounted.
+                    This is needed otherwise React will prompt 'Warning: Expected server HTML to contain a matching <div> in <div>.'
+        
+                    This is because the cached user profile cannot be retrieved on the server side, as the server does not contain the client's cookie
+                    Hence, the rendered DOM is different, causing the error.
+                    To prevent this, we need to make sure the component can only be rendered on the client.
+                    UseEffect is not run on the server
+                    
+                    More info: https://github.com/vercel/next.js/discussions/17443
+                    */}
+                    {user && isMounted && (
                         <div className="inline">
                             <h3 className="inline pr-4">Welcome {user.displayName} </h3>
                             <button

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,14 +1,7 @@
-import { useEffect, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 
 import { axInstance } from '../apis/nakvaksin.instance';
-import {
-    clearUserToken,
-    destroyUserProfile,
-    getCachedUserProfile,
-    getUserToken,
-    setUserToken
-} from '../services/auth';
+import { clearUserToken, destroyUserProfile, getUserToken } from '../services/auth';
 import User from '../types/user';
 
 const QK_USER = 'user';

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -2,7 +2,13 @@ import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { axInstance } from '../apis/nakvaksin.instance';
-import { clearUserToken, getCachedUserProfile, getUserToken, setUserToken } from '../services/auth';
+import {
+    clearUserToken,
+    destroyUserProfile,
+    getCachedUserProfile,
+    getUserToken,
+    setUserToken
+} from '../services/auth';
 import User from '../types/user';
 
 const QK_USER = 'user';
@@ -25,13 +31,15 @@ const useUser = () => {
 
     const { data: user } = useQuery<User>(QK_USER, getUser, {
         staleTime: 1000 * 86400 * 3, // 3 days
-        retry: 1,
-        initialData: getCachedUserProfile()
+        retry: 1
     });
 
-    const { mutate: logout } = useMutation(clearUserToken, {
-        onSuccess: () => queryClient.invalidateQueries(QK_USER)
-    });
+    const logout = () => {
+        clearUserToken();
+        destroyUserProfile();
+
+        queryClient.invalidateQueries(QK_USER);
+    };
 
     return { user, logout };
 };

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,7 +1,8 @@
+import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { axInstance } from '../apis/nakvaksin.instance';
-import { clearUserToken, getUserToken } from '../services/auth';
+import { clearUserToken, getCachedUserProfile, getUserToken, setUserToken } from '../services/auth';
 import User from '../types/user';
 
 const QK_USER = 'user';
@@ -24,7 +25,8 @@ const useUser = () => {
 
     const { data: user } = useQuery<User>(QK_USER, getUser, {
         staleTime: 1000 * 86400 * 3, // 3 days
-        retry: false
+        retry: 1,
+        initialData: getCachedUserProfile()
     });
 
     const { mutate: logout } = useMutation(clearUserToken, {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,21 +2,25 @@ import 'tailwindcss/tailwind.css';
 
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
+import { Hydrate } from 'react-query/hydration';
 
 import SEO from '../components/SEO';
 
-const queryClient = new QueryClient();
-
 function MyApp({ Component, pageProps }: AppProps) {
+    const [queryClient] = useState(() => new QueryClient());
+
     return (
         <QueryClientProvider client={queryClient}>
-            <Head>
-                <SEO />
-            </Head>
-            <Component {...pageProps} />
-            <ReactQueryDevtools initialIsOpen={false} />
+            <Hydrate state={pageProps.dehydratedState}>
+                <Head>
+                    <SEO />
+                </Head>
+                <Component {...pageProps} />
+                <ReactQueryDevtools initialIsOpen={false} />
+            </Hydrate>
         </QueryClientProvider>
     );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,11 @@
+import { GetServerSideProps } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 import React, { ReactElement } from 'react';
 import { GiHumanPyramid } from 'react-icons/gi';
 import { IoHeartCircleOutline, IoLogoGithub, IoNotificationsOutline } from 'react-icons/io5';
+import { QueryClient } from 'react-query';
+import { dehydrate } from 'react-query/hydration';
 
 import Header from '../components/header';
 import { useUser } from '../hooks/useUser';
@@ -44,6 +47,21 @@ const FeaturedItem = ({
         </div>
     </div>
 );
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const queryClient = new QueryClient();
+
+    const { userProfile } = context.req.cookies;
+    if (userProfile) {
+        queryClient.setQueryData('user', JSON.parse(userProfile));
+    }
+
+    return {
+        props: {
+            dehydratedState: dehydrate(queryClient)
+        }
+    };
+};
 
 export default function Home() {
     return (

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -8,7 +8,7 @@ import { useQueryClient } from 'react-query';
 
 import Header from '../components/header';
 import { useUser } from '../hooks/useUser';
-import { login, setUserProfile } from '../services/auth';
+import { login, setCachedUserProfile } from '../services/auth';
 import User from '../types/user';
 
 const ErrorMessage: React.FC = ({ children }) => (
@@ -53,7 +53,7 @@ export default function Login() {
                     const { user } = resp.data;
 
                     queryClient.setQueryData('user', user);
-                    setUserProfile(user);
+                    setCachedUserProfile(user);
                 } else {
                     throw new Error('Unexpected response from endpoint');
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -8,7 +8,7 @@ import { useQueryClient } from 'react-query';
 
 import Header from '../components/header';
 import { useUser } from '../hooks/useUser';
-import { login } from '../services/auth';
+import { login, setUserProfile } from '../services/auth';
 import User from '../types/user';
 
 const ErrorMessage: React.FC = ({ children }) => (
@@ -53,6 +53,7 @@ export default function Login() {
                     const { user } = resp.data;
 
                     queryClient.setQueryData('user', user);
+                    setUserProfile(user);
                 } else {
                     throw new Error('Unexpected response from endpoint');
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,15 +1,16 @@
+import { GetServerSideProps } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useQueryClient } from 'react-query';
+import { QueryClient, useQueryClient } from 'react-query';
+import { dehydrate } from 'react-query/hydration';
 
 import Header from '../components/header';
 import { useUser } from '../hooks/useUser';
-import { login, setCachedUserProfile } from '../services/auth';
-import User from '../types/user';
+import { login, persistUserProfile } from '../services/auth';
 
 const ErrorMessage: React.FC = ({ children }) => (
     <div className="text-sm text-red-500 mt-0.5">{children}</div>
@@ -22,6 +23,21 @@ ErrorMessage.propTypes = {
 type FormData = {
     username: string;
     password: string;
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const queryClient = new QueryClient();
+
+    const { userProfile } = context.req.cookies;
+    if (userProfile) {
+        queryClient.setQueryData('user', JSON.parse(userProfile));
+    }
+
+    return {
+        props: {
+            dehydratedState: dehydrate(queryClient)
+        }
+    };
 };
 
 export default function Login() {
@@ -53,7 +69,7 @@ export default function Login() {
                     const { user } = resp.data;
 
                     queryClient.setQueryData('user', user);
-                    setCachedUserProfile(user);
+                    persistUserProfile(user);
                 } else {
                     throw new Error('Unexpected response from endpoint');
 

--- a/pages/resetpassword.tsx
+++ b/pages/resetpassword.tsx
@@ -1,8 +1,11 @@
+import { GetServerSideProps } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { QueryClient } from 'react-query';
+import { dehydrate } from 'react-query/hydration';
 
 import Header from '../components/header';
 import { resetPassword } from '../services/auth';
@@ -18,6 +21,21 @@ ErrorMessage.propTypes = {
 
 type FormData = {
     username: string;
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const queryClient = new QueryClient();
+
+    const { userProfile } = context.req.cookies;
+    if (userProfile) {
+        queryClient.setQueryData('user', JSON.parse(userProfile));
+    }
+
+    return {
+        props: {
+            dehydratedState: dehydrate(queryClient)
+        }
+    };
 };
 
 export default function ResetPassword() {

--- a/pages/subscribe.tsx
+++ b/pages/subscribe.tsx
@@ -1,9 +1,10 @@
 import classNames from 'classnames';
-import { useRouter } from 'next/router';
-import PropTypes from 'prop-types';
-import React, { MouseEvent, ReactNode, useEffect, useState } from 'react';
+import { GetServerSideProps } from 'next';
+import React, { MouseEvent, ReactNode, useState } from 'react';
 import { GoCheck } from 'react-icons/go';
 import { IoCallOutline, IoTrashOutline } from 'react-icons/io5';
+import { QueryClient } from 'react-query';
+import { dehydrate } from 'react-query/hydration';
 
 import Header from '../components/header';
 import { useUser } from '../hooks/useUser';
@@ -116,6 +117,21 @@ const ExpandedCheckbox = ({
 //     children: PropTypes.node,
 //     checked: PropTypes.bool
 // };
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const queryClient = new QueryClient();
+
+    const { userProfile } = context.req.cookies;
+    if (userProfile) {
+        queryClient.setQueryData('user', JSON.parse(userProfile));
+    }
+
+    return {
+        props: {
+            dehydratedState: dehydrate(queryClient)
+        }
+    };
+};
 
 export default function Subscribe() {
     const { user } = useUser();

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -2,9 +2,11 @@ import axios from 'axios';
 import Cookies from 'js-cookie';
 
 import { axInstance } from '../apis/nakvaksin.instance';
+import User from '../types/user';
 import sanitizePhoneNumber from '../utils/sanitizePhoneNumber';
 
 const COOKIE_USER_TOKEN = 'userToken';
+const COOKIE_USER_PROFILE = 'userProfile';
 
 async function login(username: string, password: string) {
     return axInstance({
@@ -42,4 +44,29 @@ function clearUserToken() {
     });
 }
 
-export { clearUserToken, getUserToken, login, resetPassword, setUserToken };
+function setCachedUserProfile(user: User) {
+    Cookies.set(COOKIE_USER_PROFILE, user);
+}
+
+function getCachedUserProfile() {
+    // IMPORTANT!
+    // Do not use this function to retrieve user's profile
+    // Use useUser() hook instead
+    const cookie = Cookies.get(COOKIE_USER_PROFILE);
+
+    if (cookie) {
+        return JSON.parse(cookie) as User;
+    }
+
+    return undefined;
+}
+
+export {
+    clearUserToken,
+    getCachedUserProfile,
+    getUserToken,
+    login,
+    resetPassword,
+    setCachedUserProfile,
+    setUserToken
+};

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -30,7 +30,7 @@ async function resetPassword(username: string) {
 }
 
 function setUserToken(token: string) {
-    Cookies.set(COOKIE_USER_TOKEN, token);
+    Cookies.set(COOKIE_USER_TOKEN, token, { sameSite: 'strict' });
 }
 
 function getUserToken() {
@@ -38,35 +38,23 @@ function getUserToken() {
 }
 
 function clearUserToken() {
-    return new Promise<void>((resolve) => {
-        Cookies.remove(COOKIE_USER_TOKEN);
-        resolve();
-    });
+    Cookies.remove(COOKIE_USER_TOKEN);
 }
 
-function setCachedUserProfile(user: User) {
-    Cookies.set(COOKIE_USER_PROFILE, user);
+function persistUserProfile(user: User) {
+    Cookies.set(COOKIE_USER_PROFILE, user, { sameSite: 'strict' });
 }
 
-function getCachedUserProfile() {
-    // IMPORTANT!
-    // Do not use this function to retrieve user's profile
-    // Use useUser() hook instead
-    const cookie = Cookies.get(COOKIE_USER_PROFILE);
-
-    if (cookie) {
-        return JSON.parse(cookie) as User;
-    }
-
-    return undefined;
+function destroyUserProfile() {
+    Cookies.remove(COOKIE_USER_PROFILE);
 }
 
 export {
     clearUserToken,
-    getCachedUserProfile,
+    destroyUserProfile,
     getUserToken,
     login,
+    persistUserProfile,
     resetPassword,
-    setCachedUserProfile,
     setUserToken
 };


### PR DESCRIPTION
Issue:
Fix issue where a user gets redirected back to homepage upon refreshing `/subscribe` page.

Solution:
We are now rendering user's profile on the server to match with the client DOM.

Drawback:
There's a lot of repeated codes, you will see `getServerSideProps` in every pages now.
**NOTE: We must do it for all pages in the future.**