### PR TITLE
Log user out if token has expired or missing

### DIFF
--- a/apis/nakvaksin.instance.ts
+++ b/apis/nakvaksin.instance.ts
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios';
 import Cookies from 'js-cookie';
 import router from 'next/router';
 
-import { clearUserToken, getUserToken, setUserToken } from '../services/auth';
+import { clearUserToken, destroyUserProfile, getUserToken, setUserToken } from '../services/auth';
 
 const instance = axios.create({
     baseURL: process.env.NEXT_PUBLIC_API_URL
@@ -26,10 +26,15 @@ instance.interceptors.response.use(
     },
     (error) => {
         // unauthorized
-        // if (error.response?.status === 401) {
-        //     // clearUserToken();
-        //     // TODO: redirect user to login
-        // }
+        if (error.response?.status === 400 || error.response.status === 401) {
+            // TODO: lets refactor this axios instance to become a hook
+            // once it's a hook, only we can call logout() directly
+            //
+            // clearUserToken();
+            // destroyUserProfile();
+            // alert('You were signed out of your account. Please sign in again.');
+            // router.push('/login');
+        }
 
         return Promise.reject(error);
     }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
         const isPublicRoute = publicRoutes.includes(router.pathname);
         const isAuthenticated = !!user;
 
-        // Redirect unauthenticated user to home
+        // Redirect unauthenticated user to login
         if (!isAuthenticated && !isPublicRoute) {
             router.push('/login');
         }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
 
         // Redirect unauthenticated user to home
         if (!isAuthenticated && !isPublicRoute) {
-            router.push('/');
+            router.push('/login');
         }
     }, [user, router.pathname]);
 
@@ -37,7 +37,6 @@ export default function Header() {
                                 className="text-xl text-white bg-blue-600 rounded-xl py-1 px-4 font-bold hover:underline"
                                 onClick={() => {
                                     logout();
-                                    router.push('/');
                                 }}>
                                 Logout
                             </button>

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -3,7 +3,12 @@ import router from 'next/router';
 import { useQuery, useQueryClient } from 'react-query';
 
 import { axInstance } from '../apis/nakvaksin.instance';
-import { clearUserToken, destroyUserProfile, getUserToken } from '../services/auth';
+import {
+    clearUserToken,
+    destroyUserProfile,
+    getUserToken,
+    persistUserProfile
+} from '../services/auth';
 import User from '../types/user';
 
 const QK_USER = 'user';
@@ -27,6 +32,9 @@ const useUser = () => {
     const { data: user } = useQuery<User, AxiosError>(QK_USER, getUser, {
         staleTime: 1000 * 60 * 60, // 1 hour
         retry: 0,
+        onSuccess: (user) => {
+            persistUserProfile(user);
+        },
         onError: (error) => {
             if (error.response?.status === 400 || error.response?.status === 401) {
                 logout(true);

--- a/hooks/useVaxStatus.ts
+++ b/hooks/useVaxStatus.ts
@@ -1,8 +1,10 @@
+import { AxiosError } from 'axios';
 import { DateTime } from 'luxon';
 import { useQuery } from 'react-query';
 
 import { axInstance } from '../apis/nakvaksin.instance';
 import { VaxStatus, VaxStatusElem } from '../types/vaxStatus';
+import { useUser } from './useUser';
 
 const QK_VAXSTATUS = 'vax_status';
 
@@ -20,9 +22,16 @@ async function getVaxStatus() {
 }
 
 const useVaxStatus = () => {
-    return useQuery<VaxStatus>(QK_VAXSTATUS, getVaxStatus, {
+    const { logout } = useUser();
+
+    return useQuery<VaxStatus, AxiosError>(QK_VAXSTATUS, getVaxStatus, {
         staleTime: 1000 * 86400, // 1 days
-        retry: 1
+        retry: 1,
+        onError: (error) => {
+            if (error.response?.status === 400 || error.response?.status === 401) {
+                logout(true);
+            }
+        }
     });
 };
 

--- a/hooks/useVaxSubscription.ts
+++ b/hooks/useVaxSubscription.ts
@@ -1,7 +1,9 @@
+import { AxiosError } from 'axios';
 import { useQuery } from 'react-query';
 
 import { axInstance } from '../apis/nakvaksin.instance';
 import { VaxSubscription } from '../types/vaxSubscription';
+import { useUser } from './useUser';
 
 const QK_VAC_SUBSCRIPTION = 'vax_subscription';
 
@@ -15,9 +17,16 @@ async function getVaxSubscription() {
 }
 
 const useVaxSubscription = () => {
-    return useQuery<VaxSubscription>(QK_VAC_SUBSCRIPTION, getVaxSubscription, {
+    const { logout } = useUser();
+
+    return useQuery<VaxSubscription, AxiosError>(QK_VAC_SUBSCRIPTION, getVaxSubscription, {
         staleTime: 60 * 5 * 1000,
-        retry: 0 // TODO: in the future, dont retry only for 404 error, 404 means the user has not subscribed
+        retry: 0, // TODO: in the future, dont retry only for 404 error, 404 means the user has not subscribed
+        onError: (error) => {
+            if (error.response?.status === 400 || error.response?.status === 401) {
+                logout(true);
+            }
+        }
     });
 };
 


### PR DESCRIPTION
This solution is not pretty and consider as a workaround.

In the future, we should refactor our custom axios instance to become a hook. With that changes, we can call `logout()` directly.
The benefit of this is that, all future http request (without needing to include onError individually) will detect status 401 or 400 and automatically log the user out. 
Currently, the onError only applies to all useQuery hooks but not HTTP request such as submitting forms (`/subscribe`)