### PR TITLE
Added formatting for phone number logins

### DIFF
--- a/services/auth.ts
+++ b/services/auth.ts
@@ -9,6 +9,16 @@ const COOKIE_USER_TOKEN = 'userToken';
 const COOKIE_USER_PROFILE = 'userProfile';
 
 async function login(username: string, password: string) {
+    // Match phone numbers and format appropriately
+    const phoneMatcher = /\d{10}/;
+    if (phoneMatcher.test(username)) {
+        if (username.charAt(0) === '+') {
+            username = username.slice(1);
+        } else if (username.charAt(0) === '0') {
+            username = '6' + username;
+        }
+    }
+
     return axInstance({
         method: 'POST',
         url: '/login',

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -9,21 +9,11 @@ const COOKIE_USER_TOKEN = 'userToken';
 const COOKIE_USER_PROFILE = 'userProfile';
 
 async function login(username: string, password: string) {
-    // Match phone numbers and format appropriately
-    const phoneMatcher = /\d{10}/;
-    if (phoneMatcher.test(username)) {
-        if (username.charAt(0) === '+') {
-            username = username.slice(1);
-        } else if (username.charAt(0) === '0') {
-            username = '6' + username;
-        }
-    }
-
     return axInstance({
         method: 'POST',
         url: '/login',
         data: {
-            username,
+            username: sanitizePhoneNumber(username),
             password
         }
     });


### PR DESCRIPTION
Hey there, I just want to say thank you so much for putting this up. I can personally relate to the anxiety of having to check the MySejahtera app every day for my appointment, this would really be of great help to the people.

On MySejahtera, my phone number ID was formatted with a '+' in the beginning. I used that to login but it didn't work, so I thought that I may have forgotten my password. I went ahead and reset my password, but it still didn't work. I then tried "01..." and "601..." which eventually succeeded.

I've added a simple Regex match for phone numbers and formatting in the login function of `auth.ts` to resolve this.

PS This is my first ever open source pull request, hopefully I haven't done anything too wrong. Any advice would be greatly appreciated!